### PR TITLE
feat(core): allow using `ref` to define the `name` of field

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,22 +52,22 @@ type ValidateMode = 'blur' | 'input' | 'change' | 'submit'
 
 **Return**
 
-| Name          | Type                                                                              | Description                                                                                                                                |
-| ------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| values        | `Values`                                                                          | Current form values.                                                                                                                       |
-| errors        | `ComputedRef<FormErrors<Values>>`                                                 | Map of field name to the field has been touched                                                                                            |
-| touched       | `ComputedRef<FormTouched<Values>>`                                                | Map of field name to specific error for that field                                                                                         |
-| dirty         | `ComputedRef<boolean>`                                                            | Return `true` if current values are not deeply equal `initialValues`.                                                                      |
-| setValues     | `(values: Values, shouldValidate?: boolean)`                                      | This function allows you to dynamically update form values.                                                                                |
-| setFieldValue | `(name: string, value: unknown, shouldValidate?: boolean)`                        | This function allows you to dynamically set the value of field.                                                                            |
-| submitCount   | `ComputedRef<number>`                                                             | The number of times user attempted to submit.                                                                                              |
-| isSubmitting  | `Ref<boolean>`                                                                    | Return `true` when form is submitting, If `onSubmit()` is a synchronous function, then you need to call setSubmitting(false) on your own.  |
-| isValidating  | `ComputedRef<boolean>`                                                            | Return `true` when running validation.                                                                                                     |
-| register      | `(name: string, options?: FieldRegisterOptions<Values>) => UseFormRegisterReturn` | This method allows you to get specific field values, meta (state) and attributes, you can also add validation for that field.              |
-| handleSubmit  | `(event?: Event) => void`                                                         | Submit handler.                                                                                                                            |
-| handleReset   | `(event?: Event) => void`                                                         | Reset handler.                                                                                                                             |
-| validateForm  | `(values?: Values) => Promise<FormErrors<Values>>`                                | Validate form values.                                                                                                                      |
-| validateField | `(name: string) => Promise<void>`                                                 | Validate form specific field, if this field validation is register.                                                                        |
+| Name          | Type                                                                                             | Description                                                                                                                                |
+| ------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| values        | `Values`                                                                                         | Current form values.                                                                                                                       |
+| errors        | `ComputedRef<FormErrors<Values>>`                                                                | Map of field name to the field has been touched                                                                                            |
+| touched       | `ComputedRef<FormTouched<Values>>`                                                               | Map of field name to specific error for that field                                                                                         |
+| dirty         | `ComputedRef<boolean>`                                                                           | Return `true` if current values are not deeply equal `initialValues`.                                                                      |
+| setValues     | `(values: Values, shouldValidate?: boolean)`                                                     | This function allows you to dynamically update form values.                                                                                |
+| setFieldValue | `(name: string, value: unknown, shouldValidate?: boolean)`                                       | This function allows you to dynamically set the value of field.                                                                            |
+| submitCount   | `ComputedRef<number>`                                                                            | The number of times user attempted to submit.                                                                                              |
+| isSubmitting  | `Ref<boolean>`                                                                                   | Return `true` when form is submitting, If `onSubmit()` is a synchronous function, then you need to call setSubmitting(false) on your own.  |
+| isValidating  | `ComputedRef<boolean>`                                                                           | Return `true` when running validation.                                                                                                     |
+| register      | `(name: string \| Ref<string>, options?: FieldRegisterOptions<Values>) => UseFormRegisterReturn` | This method allows you to get specific field values, meta (state) and attributes, you can also add validation for that field.              |
+| handleSubmit  | `(event?: Event) => void`                                                                        | Submit handler.                                                                                                                            |
+| handleReset   | `(event?: Event) => void`                                                                        | Reset handler.                                                                                                                             |
+| validateForm  | `(values?: Values) => Promise<FormErrors<Values>>`                                               | Validate form values.                                                                                                                      |
+| validateField | `(name: string) => Promise<void>`                                                                | Validate form specific field, if this field validation is register.                                                                        |
 
 <br>
 
@@ -216,7 +216,7 @@ const { value: bag, attrs: bagFieldAttrs } = register('bag')
 
 | Name             | Type                                                          | Required | Description                                                                            |
 | ---------------- | ------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------- |
-| name             | `string`                                                      | ✓        | Name of the field.                                                                     |
+| name             | `string \| Ref<string>`                                       | ✓        | Name of the field.                                                                     |
 | options.validate | `(value: Value) => void \| string \| Promise<string \| void>` |          | This function allows you to write your logic to validate your field, this is optional. |
 
 **Return**
@@ -265,7 +265,7 @@ const { value, attrs } = useField<string>('ice', {
 
 | Name             | Type                                                                                  | Required | Description                                                                            |
 | ---------------- | ------------------------------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------- |
-| name             | `string`                                                                              | ✓        | Name of the field array.                                                               |
+| name             | `string \| Ref<string>`                                                               | ✓        | Name of the field array.                                                               |
 | options.validate | `(value: Value) => void \| FormErrors<Values> \| Promise<FormErrors<Values> \| void>` |          | This function allows you to write your logic to validate your field, this is optional. |
 
 **Return**

--- a/packages/core/src/composable/useField.ts
+++ b/packages/core/src/composable/useField.ts
@@ -1,5 +1,5 @@
 import { useFormInternalContext } from './useFormInternalContext';
-import type { FieldValidator, UseFormRegisterReturn } from '../types';
+import type { MaybeRef, FieldValidator, UseFormRegisterReturn } from '../types';
 
 type UseFieldOptions<Value> = {
   validate?: FieldValidator<Value>;
@@ -38,7 +38,7 @@ type UseFieldOptions<Value> = {
  * ```
  */
 export function useField<Value>(
-  name: string,
+  name: MaybeRef<string>,
   options: UseFieldOptions<Value> = {},
 ): UseFormRegisterReturn<Value> {
   const { registerField, getFieldValue, getFieldAttrs, getFieldMeta } =

--- a/packages/core/src/composable/useFieldArray.ts
+++ b/packages/core/src/composable/useFieldArray.ts
@@ -1,8 +1,9 @@
-import { ref, computed, Ref } from 'vue';
+import { ref, unref, computed, Ref } from 'vue';
 
 import { useFormInternalContext } from './useFormInternalContext';
 
 import type {
+  MaybeRef,
   FormErrors,
   FormTouched,
   FieldArrayValidator,
@@ -10,7 +11,6 @@ import type {
   Primitive,
 } from '../types';
 
-import omit from '../utils/omit';
 import appendAt from '../utils/append';
 import prependAt from '../utils/prepend';
 import swapAt from '../utils/swap';
@@ -84,7 +84,7 @@ type UseFieldArrayReturn<Value> = {
  * ```
  */
 export function useFieldArray<Value>(
-  name: string,
+  name: MaybeRef<string>,
   options?: UseFieldArrayOptions<Value>,
 ): UseFieldArrayReturn<Value> {
   const {
@@ -128,29 +128,29 @@ export function useFieldArray<Value>(
       }),
 
       name: computed(() => {
-        return `${name}.${index.value}`;
+        return `${unref(name)}.${index.value}`;
       }),
 
       error: computed(() => {
-        return getFieldError(`${name}.${index.value}`);
+        return getFieldError(`${unref(name)}.${index.value}`);
       }),
 
       touched: computed(() => {
-        return getFieldTouched(`${name}.${index.value}`);
+        return getFieldTouched(`${unref(name)}.${index.value}`);
       }),
 
       dirty: computed(() => {
-        return getFieldDirty(`${name}.${index.value}`);
+        return getFieldDirty(`${unref(name)}.${index.value}`);
       }),
 
       attrs: computed(() => {
-        return omit(getFieldAttrs(`${name}.${index.value}`), 'name');
+        return getFieldAttrs(`${unref(name)}.${index.value}`);
       }),
     } as any as FieldEntry<Value>; // `computed` will be auto unwrapped
   };
 
   const append = (value: Value) => {
-    setFieldArrayValue(name, appendAt(values.value, value), appendAt, {
+    setFieldArrayValue(unref(name), appendAt(values.value, value), appendAt, {
       argA: undefined,
     });
 
@@ -158,7 +158,7 @@ export function useFieldArray<Value>(
   };
 
   const prepend = (value: Value) => {
-    setFieldArrayValue(name, prependAt(values.value, value), prependAt, {
+    setFieldArrayValue(unref(name), prependAt(values.value, value), prependAt, {
       argA: undefined,
     });
 
@@ -169,7 +169,7 @@ export function useFieldArray<Value>(
     const cloneValues = removeAt(values.value, index);
     const cloneField = removeAt(fields.value, index);
 
-    setFieldArrayValue(name, cloneValues, removeAt, {
+    setFieldArrayValue(unref(name), cloneValues, removeAt, {
       argA: index,
     });
 
@@ -186,7 +186,7 @@ export function useFieldArray<Value>(
     swapAt(cloneField, indexA, indexB);
 
     setFieldArrayValue(
-      name,
+      unref(name),
       cloneValues,
       swapAt,
       {
@@ -209,7 +209,7 @@ export function useFieldArray<Value>(
     moveAt(cloneField, from, to);
 
     setFieldArrayValue(
-      name,
+      unref(name),
       cloneValues,
       moveAt,
       {
@@ -226,7 +226,7 @@ export function useFieldArray<Value>(
     const cloneValues = insertAt(values.value, index, value);
     const cloneField = insertAt(fields.value, index, createEntry(value));
 
-    setFieldArrayValue(name, cloneValues, insertAt, {
+    setFieldArrayValue(unref(name), cloneValues, insertAt, {
       argA: index,
       argB: undefined,
     });
@@ -239,7 +239,7 @@ export function useFieldArray<Value>(
 
     const cloneValue = updateAt(values.value, index, value);
 
-    setFieldArrayValue(name, cloneValue, updateAt, {
+    setFieldArrayValue(unref(name), cloneValue, updateAt, {
       argA: index,
       argB: undefined,
     });
@@ -250,7 +250,7 @@ export function useFieldArray<Value>(
   const replace = (values: Value[]) => {
     const cloneValues = [...values];
 
-    setFieldArrayValue(name, cloneValues, <T>(data: T): T => data, {});
+    setFieldArrayValue(unref(name), cloneValues, <T>(data: T): T => data, {});
 
     fields.value = cloneValues.map(createEntry);
   };

--- a/packages/core/src/composable/useForm.ts
+++ b/packages/core/src/composable/useForm.ts
@@ -1,4 +1,4 @@
-import { computed, reactive, ref, onMounted, provide } from 'vue';
+import { computed, reactive, ref, unref, onMounted, provide } from 'vue';
 import isEqual from 'fast-deep-equal/es6';
 import { klona as deepClone } from 'klona/full';
 import deepmerge from 'deepmerge';
@@ -17,6 +17,7 @@ import isString from '../utils/isString';
 
 import type { Reducer } from './useFormStore';
 import type {
+  MaybeRef,
   FormValues,
   FormState,
   FormErrors,
@@ -217,18 +218,20 @@ export function useForm<Values extends FormValues = FormValues>(
     state.submitCount.value === 0 ? validateMode : reValidateMode,
   );
 
-  const registerField = (name: string, { validate }: any = {}) => {
-    fieldRegistry[name] = {
+  const registerField = (name: MaybeRef<string>, { validate }: any = {}) => {
+    fieldRegistry[unref(name)] = {
       validate,
     };
   };
 
-  const registerFieldArray = (name: string, { reset, validate }: any) => {
-    fieldRegistry[name] = {
+  const registerFieldArray = (name: MaybeRef<string>, options: any) => {
+    const { validate, reset } = options;
+
+    fieldRegistry[unref(name)] = {
       validate,
     };
 
-    fieldArrayRegistry[name] = {
+    fieldArrayRegistry[unref(name)] = {
       reset,
     };
   };
@@ -366,21 +369,23 @@ export function useForm<Values extends FormValues = FormValues>(
     dispatch({ type: ACTION_TYPE.SET_ISSUBMITTING, payload: isSubmitting });
   };
 
-  const getFieldValue = (name: string) => {
+  const getFieldValue = (name: MaybeRef<string>) => {
     return computed<any>({
       get() {
-        return get(state.values, name);
+        return get(state.values, unref(name));
       },
       set(value) {
-        setFieldValue(name, value);
+        setFieldValue(unref(name), value);
       },
     });
   };
 
-  const getFieldMeta = (name: string): FieldMeta => {
-    const error = computed(() => getFieldError(name) as any as string);
-    const touched = computed(() => getFieldTouched(name) as any as boolean);
-    const dirty = computed(() => getFieldDirty(name));
+  const getFieldMeta = (name: MaybeRef<string>): FieldMeta => {
+    const error = computed(() => getFieldError(unref(name)) as any as string);
+    const touched = computed(
+      () => getFieldTouched(unref(name)) as any as boolean,
+    );
+    const dirty = computed(() => getFieldDirty(unref(name)));
 
     return {
       dirty,
@@ -389,12 +394,12 @@ export function useForm<Values extends FormValues = FormValues>(
     };
   };
 
-  const getFieldAttrs = (name: string): FieldAttrs => {
-    return {
-      name,
+  const getFieldAttrs = (name: MaybeRef<string>): FieldAttrs => {
+    return computed(() => ({
+      name: unref(name),
       onBlur: handleBlur,
       onChange: handleChange,
-    };
+    }));
   };
 
   const getFieldError = (name: string): FormErrors<any> => {
@@ -538,6 +543,7 @@ export function useForm<Values extends FormValues = FormValues>(
     registerField(name, options);
 
     return {
+      name,
       value: getFieldValue(name),
       attrs: getFieldAttrs(name),
       ...getFieldMeta(name),

--- a/packages/core/src/composable/useForm.ts
+++ b/packages/core/src/composable/useForm.ts
@@ -543,7 +543,6 @@ export function useForm<Values extends FormValues = FormValues>(
     registerField(name, options);
 
     return {
-      name,
       value: getFieldValue(name),
       attrs: getFieldAttrs(name),
       ...getFieldMeta(name),

--- a/packages/core/src/composable/useFormInternalContext.ts
+++ b/packages/core/src/composable/useFormInternalContext.ts
@@ -5,6 +5,7 @@ import {
   WritableComputedRef,
 } from 'vue';
 import {
+  MaybeRef,
   FieldValidator,
   FieldArrayValidator,
   FieldMeta,
@@ -26,26 +27,26 @@ function injectMaybeSelf<T>(
 
 export interface FormInternalContextValues {
   registerField: (
-    name: string,
+    name: MaybeRef<string>,
     options: { validate?: FieldValidator<any> },
   ) => void;
 
   registerFieldArray: (
-    name: string,
+    name: MaybeRef<string>,
     options: {
       validate?: FieldArrayValidator<any>;
       reset: () => void;
     },
   ) => void;
 
-  getFieldValue: <Value>(name: string) => WritableComputedRef<Value>;
-  getFieldMeta: (name: string) => FieldMeta;
+  getFieldValue: <Value>(name: MaybeRef<string>) => WritableComputedRef<Value>;
+  getFieldMeta: (name: MaybeRef<string>) => FieldMeta;
   setFieldValue: UseFormSetFieldValue<FormValues>;
 
   getFieldError: (name: string) => FormErrors<any>;
   getFieldTouched: (name: string) => FormTouched<any>;
   getFieldDirty: (name: string) => boolean;
-  getFieldAttrs: (name: string) => FieldAttrs;
+  getFieldAttrs: (name: MaybeRef<string>) => FieldAttrs;
 
   setFieldArrayValue: SetFieldArrayValue;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,7 @@
 import { ComputedRef, WritableComputedRef, UnwrapNestedRefs, Ref } from 'vue';
 
+export type MaybeRef<T> = T | Ref<T>;
+
 export type FormValues = Record<string, any>;
 
 export type FieldValidator<Value> = (
@@ -124,11 +126,11 @@ export interface UseFormReturn<Values extends FormValues> {
   validateField: ValidateField<Values>;
 }
 
-export interface FieldAttrs {
+export type FieldAttrs = ComputedRef<{
   name: string;
   onBlur: (event: Event) => void;
   onChange: () => void;
-}
+}>;
 
 export type FieldMeta = {
   dirty: ComputedRef<boolean>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -74,7 +74,7 @@ export type UseFormRegister<Values extends FormValues> = <
   Name extends Path<Values>,
   Value = PathValue<Values, Name>,
 >(
-  name: Name,
+  name: MaybeRef<Name>,
   options?: FieldRegisterOptions<Value>,
 ) => UseFormRegisterReturn<Value>;
 


### PR DESCRIPTION
Allow using `ref` to define the `name` of `useField()` and `useFieldArray()`, like bellow

```ts
import { ref } from 'vue'
import { useField } from '@vorms/core'

const nameRef = ref('name')
const { value } = useField(nameRef)
```

If want create field component with vorms, that is vary useful.

```vue
<script setup lang="ts">
import { toRef } from 'vue'
import { useField } from '@vorms/core'

const props = defineProps({
  name: {
    type: string,
    required: true
  }
})

const nameRef = toRef(props, 'name')
const { value, attrs } = useField(nameRef)
</script>

<template>
  <input v-model="value" type="text" v-bind="attrs" />
</template>
```