### PR TITLE
feat(core)!: change the implementation of `validationMode`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ type UseFormRegisterReturn<Value> =  {
     name: string
     onBlur: () => void;
     onChange: () => void;
+    onInput: () => void
   };
 }
 
@@ -230,6 +231,7 @@ const { value: bag, attrs: bagFieldAttrs } = register('bag')
 | attrs.name     | `string`                            | Input's name that we pass by.                                        |
 | attrs.onBlur   | `(event: Event) => void`            | onBlur prop to subscribe the input blur event.                       |
 | attrs.onChange | `() => void`                        | onChange prop to subscribe the input change event.                   |
+| attrs.onInput  | `() => void`                        | onInput prop to subscribe the input input event.                     |
 
 **Example**
 
@@ -295,6 +297,7 @@ interface FieldEntry {
   attrs: {
     onBlur: (event: Event) => void;
     onChange: () => void;
+    onInput: () => void
   };
 }
 ```

--- a/packages/core/src/composable/useForm.ts
+++ b/packages/core/src/composable/useForm.ts
@@ -286,12 +286,7 @@ export function useForm<Values extends FormValues = FormValues>(
       },
     });
 
-    const willValidate =
-      shouldValidate == null
-        ? validateTiming.value === 'input'
-        : shouldValidate;
-
-    return willValidate
+    return shouldValidate
       ? runAllValidateHandler(state.values)
       : Promise.resolve();
   };
@@ -372,6 +367,12 @@ export function useForm<Values extends FormValues = FormValues>(
     }
   };
 
+  const handleInput: FormEventHandler['handleInput'] = () => {
+    if (validateTiming.value === 'input') {
+      runAllValidateHandler(state.values);
+    }
+  };
+
   const setSubmitting = (isSubmitting: boolean) => {
     dispatch({ type: ACTION_TYPE.SET_ISSUBMITTING, payload: isSubmitting });
   };
@@ -404,6 +405,7 @@ export function useForm<Values extends FormValues = FormValues>(
       name: unref(name),
       onBlur: handleBlur,
       onChange: handleChange,
+      onInput: handleInput,
     }));
   };
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -48,6 +48,7 @@ export interface FormEventHandler {
   };
 
   handleChange: () => void;
+  handleInput: () => void;
 }
 
 export interface FieldRegisterOptions<Values> {
@@ -130,6 +131,7 @@ export type FieldAttrs = {
   name: string;
   onBlur: (event: Event) => void;
   onChange: () => void;
+  onInput: () => void;
 };
 
 export type FieldMeta = {


### PR DESCRIPTION
### 🔗 Linked issue

No issues linked to this PR

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently, Vorms's `validationMode` and `reValidationMode` support `blur`, `change`, `submit` and `input`. All modes except `input` rely on the corresponding native event, while the `input` mode relies on the implementation of `setFieldValue()`.

The current implementation caused two problems:
1. Unintuitive, you may not want to trigger validation when calling `setFieldValue()` manually.
2. Integration with some UI frameworks is error-prone.

This PR will resolve that, it is going to support `input` mode with native events.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.