### PR TITLE
refactor(core)!: remove deprecated api

### DIFF
--- a/packages/core/src/composables/useForm.ts
+++ b/packages/core/src/composables/useForm.ts
@@ -58,10 +58,6 @@ export interface UseFormOptions<Values extends FormValues> {
   validateOnMounted?: boolean;
   onSubmit: (values: Values, helper: FormSubmitHelper) => void | Promise<any>;
   onInvalid?: (errors: FormErrors<Values>) => void;
-  /**
-   * @deprecated Will be removed in a major release. Please use `onInvalid()` instead.
-   */
-  onError?: (errors: FormErrors<Values>) => void;
   validate?: (values: Values) => void | object | Promise<FormErrors<Values>>;
 }
 
@@ -199,7 +195,6 @@ export function useForm<Values extends FormValues = FormValues>(
     validateMode = 'submit',
     reValidateMode = 'change',
     onSubmit,
-    onError,
     onInvalid,
   } = options;
 
@@ -514,7 +509,6 @@ export function useForm<Values extends FormValues = FormValues>(
       } else {
         dispatch({ type: ACTION_TYPE.SUBMIT_FAILURE });
         onInvalid?.(errors);
-        onError?.(errors);
       }
     });
   };


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Remove deprecated api. Those APIs are still compatible in v1.0.0-rc.2.

Overview: 

- Remove `onError(errors)`, use `onInvalid(errors)` instead.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guidelines](https://github.com/Mini-ghost/vorms/blob/main/CONTRIBUTING.md).
- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
