### PR TITLE
feat(core): add `setErrors` and `setFieldError`

### DIFF
--- a/docs/api/use-form.md
+++ b/docs/api/use-form.md
@@ -293,6 +293,18 @@ This function allows you to manually set the specific value of field.
 
 - Type `(name: string, value: unknown, shouldValidate?: boolean)`
 
+### setErrors
+
+This function allows you to manually set form errors.
+
+- Type `(errors: FormErrors<Values>)`
+
+### setFieldError
+
+This function allows you to manually set the specific error of field.
+
+- Type `(name: string, error: string | string[] | Record<string, any> | undefined)`
+
 ### submitCount
 
 The number of times user attempted to submit.

--- a/packages/core/src/composables/useForm.ts
+++ b/packages/core/src/composables/useForm.ts
@@ -402,8 +402,10 @@ export function useForm<Values extends FormValues = FormValues>(
     });
   };
 
-  const getFieldMeta = (name: MaybeRefOrGetter<string>): FieldMeta => {
-    const error = computed(() => getFieldError(name) as any as string);
+  const getFieldMeta = <Name extends Path<Values>>(
+    name: MaybeRefOrGetter<Name>,
+  ): FieldMeta<PathValue<Values, Name>> => {
+    const error = computed(() => getFieldError(name));
     const touched = computed(() => getFieldTouched(name));
     const dirty = computed(() => getFieldDirty(name));
 

--- a/packages/core/src/composables/useInternalContext.ts
+++ b/packages/core/src/composables/useInternalContext.ts
@@ -43,7 +43,7 @@ export interface InternalContextValues {
   getFieldDirty: (name: string) => boolean;
   getFieldAttrs: (name: MaybeRef<string>) => ComputedRef<FieldAttrs>;
 
-  setFieldArrayValue: SetFieldArrayValue;
+  setFieldArrayValue: SetFieldArrayValue<FormValues>;
 
   register: UseFormRegister<FormValues>;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -28,8 +28,8 @@ export type FormErrors<Values> = {
       ? FormErrors<Values[K][number]>[] | string | string[]
       : string | string[]
     : Values[K] extends object
-    ? FormErrors<Values[K]>
-    : string;
+    ? FormErrors<Values[K]> | string | string[]
+    : string | string[];
 };
 
 export interface FormState<Values extends FormValues> {
@@ -60,8 +60,11 @@ export type UseFormRegisterReturn<Value> = FieldMeta & {
   attrs: ComputedRef<FieldAttrs>;
 };
 
-export type SetFieldArrayValue = <T extends (...args: any) => any>(
-  name: string,
+export type SetFieldArrayValue<Values extends FormValues> = <
+  Name extends Path<Values>,
+  T extends (...args: any) => any,
+>(
+  name: Name,
   value: any[],
   method?: T,
   args?: Partial<{
@@ -98,6 +101,13 @@ export type ValidateField<Values extends FormValues> = <
   name: Name,
 ) => Promise<void>;
 
+export type UseFormSetFieldError<Values extends FormValues> = <
+  Name extends Path<Values>,
+>(
+  name: Name,
+  error: FormErrors<PathValue<Values, Name>> | string | string[],
+) => void;
+
 export interface FormResetState<Values extends FormValues = FormValues> {
   values: Values;
   touched: FormTouched<Values>;
@@ -120,6 +130,8 @@ export interface UseFormReturn<Values extends FormValues> {
   register: UseFormRegister<Values>;
   setValues: (values: Values, shouldValidate?: boolean) => void;
   setFieldValue: UseFormSetFieldValue<Values>;
+  setErrors: (errors: FormErrors<Values>) => void;
+  setFieldError: UseFormSetFieldError<Values>;
   handleSubmit: (event?: Event) => void;
   handleReset: (event?: Event) => void;
   resetForm: ResetForm<Values>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2,16 +2,17 @@ import { ComputedRef, Ref, WritableComputedRef } from 'vue';
 
 export type MaybeRef<T> = T | Ref<T>;
 export type MaybeRefOrGetter<T> = MaybeRef<T> | (() => T);
+export type MaybePromise<T> = T | Promise<T>;
 
 export type FormValues = Record<string, any>;
 
 export type FieldValidator<Value> = (
   value: Value,
-) => string | void | Promise<string | void>;
+) => MaybePromise<FieldError<Value>>;
 
 export type FieldArrayValidator<Value extends Array<any>> = (
   value: Value,
-) => FormErrors<Value> | void | Promise<FormErrors<Value> | void>;
+) => MaybePromise<FormErrors<Value> | void>;
 
 export type FormTouched<Values> = {
   [K in keyof Values]?: Values[K] extends any[]
@@ -32,6 +33,10 @@ export type FormErrors<Values> = {
     ? FormErrors<Values[K]> | string | string[]
     : string | string[];
 };
+
+export type FieldError<Value> = Value extends Primitive
+  ? string | string[] | void
+  : string | string[] | FormErrors<Value> | void;
 
 export interface FormState<Values extends FormValues> {
   values: Values;
@@ -56,7 +61,7 @@ export interface FieldRegisterOptions<Values> {
   validate?: FieldValidator<Values>;
 }
 
-export type UseFormRegisterReturn<Value> = FieldMeta & {
+export type UseFormRegisterReturn<Value> = FieldMeta<Value> & {
   value: WritableComputedRef<Value>;
   attrs: ComputedRef<FieldAttrs>;
 };
@@ -147,9 +152,9 @@ export type FieldAttrs = {
   onInput: () => void;
 };
 
-export type FieldMeta = {
+export type FieldMeta<Value> = {
   dirty: ComputedRef<boolean>;
-  error: ComputedRef<string | undefined>;
+  error: ComputedRef<FormErrors<Value>>;
   touched: ComputedRef<boolean | undefined>;
 };
 

--- a/packages/core/tests/composables/useForm.test.ts
+++ b/packages/core/tests/composables/useForm.test.ts
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils';
 import { describe, expect, it, vi } from 'vitest';
+import { s } from 'vitest/dist/env-afee91f0';
 import { defineComponent, nextTick, ref } from 'vue';
 
 import { useForm } from '../../src';
@@ -1154,5 +1155,43 @@ describe('useForm', () => {
     });
 
     await wrapper.find('button').trigger('click');
+  });
+
+  it('when errors changes via setErrors', () => {
+    setup(() => {
+      const { errors, setErrors, handleSubmit } = useForm({
+        initialValues: {
+          name: '',
+        },
+        onSubmit: noop,
+      });
+
+      expect(errors.value).toEqual({});
+
+      setErrors({ name: 'name is required' });
+      expect(errors.value).toEqual({
+        name: 'name is required',
+      });
+
+      handleSubmit();
+    });
+  });
+
+  it('when errors changes via setErrors', () => {
+    setup(() => {
+      const { errors, setFieldError } = useForm({
+        initialValues: {
+          name: '',
+        },
+        onSubmit: noop,
+      });
+
+      expect(errors.value).toEqual({});
+
+      setFieldError('name', 'name is required');
+      expect(errors.value).toEqual({
+        name: 'name is required',
+      });
+    });
   });
 });


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #17 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- **Add `setErrors` and `setFieldError`**

  Currently, in Vorms, it is not possible to set errors without performing validation. This limitation becomes inconvenient when we encounter errors in API responses that do not adhere to the predefined validation rules.

  To address this issue, we have introduced two new methods, `setError` and `setFieldError`, in this PR. These methods can be used within the `handleSubmit` function to provide error feedback to the user after performing asynchronous validation. (ex: API response validation errors occur).

- **More flexible error message type**

  According to #17, there are cases where we need to provide a list of error messages for a field, displaying all the reasons for failure to the user, instead of just a single error message string.

  In the current version, we can still use an array of strings to return a list of error messages, and it works, but dealing with type errors can be frustrating.

  With this PR, we introduce a solution that allows us to return an error message, which can be either a string or an array of strings, without encountering type errors. This improvement ensures a smoother experience by providing flexibility in handling error messages, accommodating both single and multiple failure reasons.

### 📝 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/Mini-ghost/vorms/blob/main/CONTRIBUTING.md).
- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
