### PR TITLE
feat(core): allow passing getter as field name

### DIFF
--- a/docs/api/use-field-array.md
+++ b/docs/api/use-field-array.md
@@ -44,7 +44,7 @@ const { fields, append } = useFieldArray<string>('foods')
 
 Name of the field array.
 
-- Type `MaybeRef<string>`
+- Type `MaybeRefOrGetter<string>`
 
 ### options
 

--- a/docs/api/use-field.md
+++ b/docs/api/use-field.md
@@ -27,15 +27,14 @@ const { value, error, attrs } = useField<string>('drink', {
 
 ### name (Required)
 
-The name of a specific field. Its type can be `string` or `Ref<string>`
+The name of a specific field. Its type can be `string`, `Ref<string>` or `() => string`
 
-- Type `MaybeRef<string>`
+- Type `MaybeRefOrGetter<string>`
 
 If you want to create a custom component in your application, such as `<TextField />`, you should use `Ref<string>` to retain reactivity for `props.name`. as follows:
 
 ```vue
 <script setup lang="ts">
-import { toRef } from 'vue'
 import { useField } from '@vorms/core'
 
 interface TextFieldProps {
@@ -45,8 +44,8 @@ interface TextFieldProps {
 const props = defineProps<TextFieldProps>()
 
 // or using `const nameSync = computed(() => props.name)`
-const nameRef = toRef(props, 'name')
-const { value } = useField<string>(nameRef)
+// or using `const nameRef = toRef(props, 'name')`
+const { value } = useField<string>(() => 'name')
 </script>
 ```
 

--- a/docs/api/use-form.md
+++ b/docs/api/use-form.md
@@ -339,7 +339,7 @@ This method allows you to get the specific field value, meta (state) and attribu
 - Type
 
   ```ts
-  function register<Value>(name: MaybeRef<string>,  options?: FieldRegisterOptions<Value>): UseFormRegisterReturn<Value>
+  function register<Value>(name: MaybeRefOrGetter<string>,  options?: FieldRegisterOptions<Value>): UseFormRegisterReturn<Value>
   ```
 
   <details>

--- a/packages/core/src/composables/toValue.ts
+++ b/packages/core/src/composables/toValue.ts
@@ -1,0 +1,8 @@
+import { unref } from 'vue';
+
+import { MaybeRefOrGetter } from '../types';
+import isFunction from '../utils/isFunction';
+
+export default <T>(value: MaybeRefOrGetter<T>): T => {
+  return isFunction(value) ? value() : unref(value);
+};

--- a/packages/core/src/composables/useField.ts
+++ b/packages/core/src/composables/useField.ts
@@ -1,6 +1,10 @@
 import { useInternalContext } from './useInternalContext';
 
-import type { FieldValidator, MaybeRef, UseFormRegisterReturn } from '../types';
+import type {
+  FieldValidator,
+  MaybeRefOrGetter,
+  UseFormRegisterReturn,
+} from '../types';
 
 type UseFieldOptions<Value> = {
   validate?: FieldValidator<Value>;
@@ -39,12 +43,9 @@ type UseFieldOptions<Value> = {
  * ```
  */
 export function useField<Value>(
-  name: MaybeRef<string>,
+  name: MaybeRefOrGetter<string>,
   options: UseFieldOptions<Value> = {},
 ): UseFormRegisterReturn<Value> {
   const { register } = useInternalContext();
-
-  register(name, options);
-
   return register(name, options);
 }

--- a/packages/core/src/composables/useInternalContext.ts
+++ b/packages/core/src/composables/useInternalContext.ts
@@ -12,7 +12,7 @@ import {
   FormErrors,
   FormTouched,
   FormValues,
-  MaybeRef,
+  MaybeRefOrGetter,
   SetFieldArrayValue,
   UseFormRegister,
   UseFormSetFieldValue,
@@ -28,20 +28,22 @@ function injectMaybeSelf<T>(
 
 export interface InternalContextValues {
   registerFieldArray: (
-    name: MaybeRef<string>,
+    name: MaybeRefOrGetter<string>,
     options: {
       validate?: FieldArrayValidator<any>;
       reset: () => void;
     },
   ) => void;
 
-  getFieldValue: <Value>(name: MaybeRef<string>) => WritableComputedRef<Value>;
+  getFieldValue: <Value>(
+    name: MaybeRefOrGetter<string>,
+  ) => WritableComputedRef<Value>;
   setFieldValue: UseFormSetFieldValue<FormValues>;
 
-  getFieldError: (name: string) => FormErrors<any>;
-  getFieldTouched: (name: string) => FormTouched<boolean>;
-  getFieldDirty: (name: string) => boolean;
-  getFieldAttrs: (name: MaybeRef<string>) => ComputedRef<FieldAttrs>;
+  getFieldError: (name: MaybeRefOrGetter<string>) => FormErrors<any>;
+  getFieldTouched: (name: MaybeRefOrGetter<string>) => FormTouched<boolean>;
+  getFieldDirty: (name: MaybeRefOrGetter<string>) => boolean;
+  getFieldAttrs: (name: MaybeRefOrGetter<string>) => ComputedRef<FieldAttrs>;
 
   setFieldArrayValue: SetFieldArrayValue;
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,6 +1,7 @@
-import { ComputedRef, Ref, UnwrapNestedRefs, WritableComputedRef } from 'vue';
+import { ComputedRef, Ref, WritableComputedRef } from 'vue';
 
 export type MaybeRef<T> = T | Ref<T>;
+export type MaybeRefOrGetter<T> = MaybeRef<T> | (() => T);
 
 export type FormValues = Record<string, any>;
 
@@ -33,7 +34,7 @@ export type FormErrors<Values> = {
 };
 
 export interface FormState<Values extends FormValues> {
-  values: UnwrapNestedRefs<Values>;
+  values: Values;
   touched: Ref<FormTouched<Values>>;
   errors: Ref<FormErrors<Values>>;
   submitCount: Ref<number>;
@@ -75,7 +76,7 @@ export type UseFormRegister<Values extends FormValues> = <
   Name extends Path<Values>,
   Value = PathValue<Values, Name>,
 >(
-  name: MaybeRef<Name>,
+  name: MaybeRefOrGetter<Name>,
   options?: FieldRegisterOptions<Value>,
 ) => UseFormRegisterReturn<Value>;
 
@@ -83,7 +84,7 @@ export type UseFormSetFieldValue<Values extends FormValues> = <
   Name extends Path<Values>,
   FieldValue extends PathValue<Values, Name>,
 >(
-  name: Name,
+  name: MaybeRefOrGetter<Name>,
   value: FieldValue,
   shouldValidate?: boolean,
 ) => void;
@@ -110,7 +111,7 @@ export type ResetForm<Values extends FormValues> = (
 ) => void;
 
 export interface UseFormReturn<Values extends FormValues> {
-  values: UnwrapNestedRefs<Values>;
+  values: Values;
   touched: ComputedRef<FormTouched<Values>>;
   errors: ComputedRef<FormErrors<Values>>;
   submitCount: ComputedRef<number>;

--- a/packages/core/tests/composables/useFieldArray.test.ts
+++ b/packages/core/tests/composables/useFieldArray.test.ts
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
-import { defineComponent } from 'vue';
+import { defineComponent, ref } from 'vue';
 
 import { useFieldArray, useForm } from '../../src';
 
@@ -344,6 +344,82 @@ describe('useFieldArray', () => {
 
       expect(fields.value[0].value).toEqual(2);
       expect(fields.value[0].dirty).toEqual(true);
+    });
+  });
+
+  it('when use ref for field name', () => {
+    setup(() => {
+      useForm({
+        initialValues: {
+          list1: [0, 1, 2],
+          list2: [3, 4, 5],
+        },
+        initialErrors: {
+          list1: ['error 0', 'error 1', 'error 2'],
+          list2: ['error 3', 'error 4', 'error 5'],
+        },
+        initialTouched: {
+          list1: [true, true, true],
+          list2: [false, false, false],
+        },
+        onSubmit: noop,
+      });
+
+      const name = ref<'list1' | 'list2'>('list1');
+      const { fields, prepend } = useFieldArray(name);
+
+      expect(fields.value[0].value).toEqual(0);
+      expect(fields.value[0].error).toEqual('error 0');
+      expect(fields.value[0].touched).toEqual(true);
+
+      name.value = 'list2';
+      expect(fields.value[0].value).toEqual(3);
+      expect(fields.value[0].error).toEqual('error 3');
+      expect(fields.value[0].touched).toEqual(false);
+
+      prepend(6);
+      expect(fields.value[0].value).toEqual(6);
+
+      name.value = 'list1';
+      expect(fields.value[0].value).toEqual(0);
+    });
+  });
+
+  it('when use getter for field name', () => {
+    setup(() => {
+      useForm({
+        initialValues: {
+          list1: [0, 1, 2],
+          list2: [3, 4, 5],
+        },
+        initialErrors: {
+          list1: ['error 0', 'error 1', 'error 2'],
+          list2: ['error 3', 'error 4', 'error 5'],
+        },
+        initialTouched: {
+          list1: [true, true, true],
+          list2: [false, false, false],
+        },
+        onSubmit: noop,
+      });
+
+      const name = ref<'list1' | 'list2'>('list1');
+      const { fields, prepend } = useFieldArray(() => name.value);
+
+      expect(fields.value[0].value).toEqual(0);
+      expect(fields.value[0].error).toEqual('error 0');
+      expect(fields.value[0].touched).toEqual(true);
+
+      name.value = 'list2';
+      expect(fields.value[0].value).toEqual(3);
+      expect(fields.value[0].error).toEqual('error 3');
+      expect(fields.value[0].touched).toEqual(false);
+
+      prepend(6);
+      expect(fields.value[0].value).toEqual(6);
+
+      name.value = 'list1';
+      expect(fields.value[0].value).toEqual(0);
     });
   });
 });

--- a/packages/core/tests/composables/useForm.test.ts
+++ b/packages/core/tests/composables/useForm.test.ts
@@ -751,6 +751,29 @@ describe('useForm', () => {
     });
   });
 
+  it('when use getter for register name', () => {
+    setup(() => {
+      const { register } = useForm({
+        initialValues: {
+          name: 'Alex',
+          city: 'Taichung',
+        },
+        onSubmit: noop,
+      });
+
+      const name = ref<'name' | 'city'>('name');
+      const { value, attrs } = register(() => name.value);
+
+      expect(value.value).toEqual('Alex');
+      expect(attrs.value.name).toEqual('name');
+
+      name.value = 'city';
+
+      expect(value.value).toEqual('Taichung');
+      expect(attrs.value.name).toEqual('city');
+    });
+  });
+
   it('when onSubmit with validation error', async () => {
     const onSubmit = vi.fn();
     const Comp = defineComponent({


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

**Allowing the use of a getter function as a field name**

Currently, in Vorms, it is possible to define the name of `useField()` and `useFieldArray()` by utilizing a `ref` object. 

```vue
<script setup lang="ts">
import { toRef } from 'vue'
import { useField } from '@vorms/core'

const props = defineProps(['name'])

// or useField(computed(() => props.name))
const { value, attrs } = useField(toRef(props, 'name'))
</script>

<template>
  <input v-model="value" type="text" v-bind="attrs" />
</template>
```

However, this PR introduces an enhancement that allows for the use of a getter function as the field name. We can simplify the example as follows:

```vue
<script setup lang="ts">
import { useField } from '@vorms/core'

const props = defineProps(['name'])
const { value, attrs } = useField(() => props.name)
</script>

<template>
  <input v-model="value" type="text" v-bind="attrs" />
</template>
```

By incorporating this change, the code becomes more streamlined and efficient.

### 📝 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/Mini-ghost/vorms/blob/main/CONTRIBUTING.md).
- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
