### PR TITLE
feat(core): support for generics to define validated values

### DIFF
--- a/packages/core/src/composables/useForm.ts
+++ b/packages/core/src/composables/useForm.ts
@@ -56,7 +56,7 @@ export type ValidateMode = 'blur' | 'input' | 'change' | 'submit';
 
 export interface UseFormOptions<
   Values extends FormValues,
-  TransformedValues extends FormValues | undefined = undefined,
+  ValidatedValues extends FormValues | undefined = undefined,
 > {
   initialValues: Values;
   initialErrors?: FormErrors<Values>;
@@ -65,7 +65,7 @@ export interface UseFormOptions<
   reValidateMode?: ValidateMode;
   validateOnMounted?: boolean;
   onSubmit: (
-    values: TransformedValues extends FormValues ? TransformedValues : Values,
+    values: ValidatedValues extends FormValues ? ValidatedValues : Values,
     helper: FormSubmitHelper<Values>,
   ) => void | Promise<any>;
   onInvalid?: (errors: FormErrors<Values>) => void;
@@ -200,8 +200,8 @@ const emptyTouched: FormTouched<unknown> = {};
  */
 export function useForm<
   Values extends FormValues = FormValues,
-  TransformedValues extends FormValues | undefined = undefined,
->(options: UseFormOptions<Values, TransformedValues>): UseFormReturn<Values> {
+  ValidatedValues extends FormValues | undefined = undefined,
+>(options: UseFormOptions<Values, ValidatedValues>): UseFormReturn<Values> {
   const {
     validateOnMounted = false,
     validateMode = 'submit',
@@ -526,8 +526,8 @@ export function useForm<
 
       if (isValid) {
         const maybePromise = onSubmit(
-          deepClone(state.values) as TransformedValues extends FormValues
-            ? TransformedValues
+          deepClone(state.values) as ValidatedValues extends FormValues
+            ? ValidatedValues
             : Values,
           submitHelper,
         );

--- a/packages/core/src/composables/useForm.ts
+++ b/packages/core/src/composables/useForm.ts
@@ -54,7 +54,10 @@ export interface FormSubmitHelper<Values extends FormValues> {
 
 export type ValidateMode = 'blur' | 'input' | 'change' | 'submit';
 
-export interface UseFormOptions<Values extends FormValues> {
+export interface UseFormOptions<
+  Values extends FormValues,
+  TransformedValues extends FormValues | undefined = undefined,
+> {
   initialValues: Values;
   initialErrors?: FormErrors<Values>;
   initialTouched?: FormTouched<Values>;
@@ -62,7 +65,7 @@ export interface UseFormOptions<Values extends FormValues> {
   reValidateMode?: ValidateMode;
   validateOnMounted?: boolean;
   onSubmit: (
-    values: Values,
+    values: TransformedValues extends FormValues ? TransformedValues : Values,
     helper: FormSubmitHelper<Values>,
   ) => void | Promise<any>;
   onInvalid?: (errors: FormErrors<Values>) => void;
@@ -195,9 +198,10 @@ const emptyTouched: FormTouched<unknown> = {};
  * </template>
  * ```
  */
-export function useForm<Values extends FormValues = FormValues>(
-  options: UseFormOptions<Values>,
-): UseFormReturn<Values> {
+export function useForm<
+  Values extends FormValues = FormValues,
+  TransformedValues extends FormValues | undefined = undefined,
+>(options: UseFormOptions<Values, TransformedValues>): UseFormReturn<Values> {
   const {
     validateOnMounted = false,
     validateMode = 'submit',
@@ -521,7 +525,12 @@ export function useForm<Values extends FormValues = FormValues>(
       const isValid = keysOf(errors).length === 0;
 
       if (isValid) {
-        const maybePromise = onSubmit(deepClone(state.values), submitHelper);
+        const maybePromise = onSubmit(
+          deepClone(state.values) as TransformedValues extends FormValues
+            ? TransformedValues
+            : Values,
+          submitHelper,
+        );
         if (maybePromise == null) {
           return;
         }


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Now, we can define the type of the entire form data `values` using the generic `Values`. However, the value in `onSubmit` may be the final value after being validated by a validation function, which may differ from the initial value's type.

```ts
interface Values {
  count: number | null
}

useForm<Values>({
  initialValues: {
    count: null
  },
  validate(values) {
    // Validate to make sure the count field is a number 
  },
  onSubmit(values) {
    console.log(values.count) // this type is `null | number` 
  }
})
```

Here, we may need some special handling to resolve the type issue, such as using assertions. But after this PR, we support defining the type of validated values:

```ts
interface Values {
  count: number | null
}

interface ValidatedValues {
  count: number
}

useForm<Values, ValidatedValues>({
  initialValues: {
    count: null
  },
  validate(values) {
    // Validate to make sure the count field is a number 
  },
  onSubmit(values) {
    console.log(values) // `values.count` type is number 
  }
})
```

This change is backward compatible, so you don't have to worry about modifying the existing code. However, in the future, when handling `onSubmit`, you can avoid many annoying type assertions.

### 📝 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/Mini-ghost/vorms/blob/main/CONTRIBUTING.md).
- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
