### PR TITLE
fix(resolvers): add resolver types exports

### DIFF
--- a/packages/resolvers/package.json
+++ b/packages/resolvers/package.json
@@ -9,22 +9,26 @@
     ".": {
       "import": "./dist/index.esm.mjs",
       "require": "./dist/index.cjs.js",
-      "umd": "./dist/index.umd.js"
+      "umd": "./dist/index.umd.js",
+      "types": "./dist/index.d.ts"
     },
     "./valibot": {
       "import": "./valibot/dist/index.esm.mjs",
       "require": "./valibot/dist/index.cjs.js",
-      "umd": "./valibot/dist/index.umd.js"
+      "umd": "./valibot/dist/index.umd.js",
+      "types": "./valibot/dist/index.d.ts"
     },
     "./yup": {
       "import": "./yup/dist/index.esm.mjs",
       "require": "./yup/dist/index.cjs.js",
-      "umd": "./yup/dist/index.umd.js"
+      "umd": "./yup/dist/index.umd.js",
+      "types": "./yup/dist/index.d.ts"
     },
     "./zod": {
       "import": "./zod/dist/index.esm.mjs",
       "require": "./zod/dist/index.cjs.js",
-      "umd": "./zod/dist/index.umd.js"
+      "umd": "./zod/dist/index.umd.js",
+      "types": "./zod/dist/index.d.ts"
     }
   },
   "files": [


### PR DESCRIPTION
### 🔗 Linked issue

[#35](https://github.com/Mini-ghost/vorms/issues/35)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This change makes the resolver package usable with `"moduleResolution": "Bundler"`. The types of the packages are exported explicitly now.  
Please note that this is a quick fix. To be really close to current TypeScript standards, .mts and .cjs files should be generated in addition to .d.ts files. [Look here](https://www.typescriptlang.org/docs/handbook/esm-node.html#new-file-extensions) for further information.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guidelines](https://github.com/Mini-ghost/vorms/blob/main/CONTRIBUTING.md).
- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
