### PR TITLE
fix(core): resolve 'Excessive stack depth comparing types' error

### DIFF
--- a/packages/core/src/composables/useForm.ts
+++ b/packages/core/src/composables/useForm.ts
@@ -103,7 +103,7 @@ type FormMessage<Values extends FormValues> =
       type: ACTION_TYPE.SET_FIELD_ERROR;
       payload: {
         path: string;
-        error: FormErrors<PathValue<Values, Path<Values>>> | string | string[];
+        error: FieldError<PathValue<Values, Path<Values>>> | string | string[];
       };
     }
   | { type: ACTION_TYPE.SET_ISSUBMITTING; payload: boolean }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -111,7 +111,7 @@ export type UseFormSetFieldError<Values extends FormValues> = <
   Name extends Path<Values>,
 >(
   name: Name,
-  error: FormErrors<PathValue<Values, Name>> | string | string[],
+  error: FieldError<PathValue<Values, Name>> | string | string[],
 ) => void;
 
 export interface FormResetState<Values extends FormValues = FormValues> {


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

!['Excessive stack depth comparing types' error](https://github.com/Mini-ghost/vorms/assets/39984251/149e8f9e-e513-4c1d-8205-7a9fa99fd1b4)

I addressed the 'Excessive stack depth comparing types' error by modifying the type definitions in the codebase. Specifically:
- Updated the `UseFormSetFieldError` type definition by replacing `FormErrors` with `FieldError` in the signature.
- Adjusted the `FormMessage` type definition to align with `FieldError` instead of `FormErrors`.

### 📝 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/Mini-ghost/vorms/blob/main/CONTRIBUTING.md).
- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
