### PR TITLE
feat(core): `validateField` supports returning validation results

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -101,13 +101,13 @@ export type ValidateField<Values extends FormValues> = <
   Name extends Path<Values>,
 >(
   name: Name,
-) => Promise<void>;
+) => Promise<FieldError<PathValue<Values, Name>> | void>;
 
 export type UseFormSetFieldError<Values extends FormValues> = <
   Name extends Path<Values>,
 >(
   name: Name,
-  error: FieldError<PathValue<Values, Name>> | string | string[],
+  error: FieldError<PathValue<Values, Name>>,
 ) => void;
 
 export type UseFormSetFieldTouched<Values extends FormValues> = <


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

**Before**

```ts
const error = validateField('fieldName')
// The `error` is `undefined` even if validation fails
```

**After**

```ts
const error = validateField('fieldName')
// The `error` is `FieldError<Values, Name>` if validation fails
```

### 📝 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/Mini-ghost/vorms/blob/main/CONTRIBUTING.md).
- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
