### PR TITLE
docs: remove duplicate 'half' enum definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ dist
 coverage
 
 .DS_STORE
-
+.idea

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ It will be exposed to global as `window.Vorms`
 ```ts
 import { useForm } from '@vorms/core'
 
-const sugarOptions = ['no', 'light', 'half', 'half', 'standard']
+const sugarOptions = ['no', 'light', 'half', 'standard']
 
 const { register, handleSubmit, handleReset } = useForm({
   initialValues: {

--- a/docs/advanced/smart-form-component.md
+++ b/docs/advanced/smart-form-component.md
@@ -12,7 +12,7 @@ import SmartSelect from './components/SmartSelect.vue'
 
 interface Values {
   drink: string,
-  sugar: 'no' | 'light' | 'half' | 'half' | 'standard'
+  sugar: 'no' | 'light' | 'half' | 'standard'
 }
 
 const initialValues = {
@@ -31,7 +31,7 @@ const onSubmit = (values: Values) => {
   <div>
     <SmartForm :initial-values="initialValues" @submit="onSubmit">
       <SmartTextField name="name" />
-      <SmartSelect name="sugar" :options="['no', 'light', 'half', 'half', 'standard']" />
+      <SmartSelect name="sugar" :options="['no', 'light', 'half', 'standard']" />
 
       <button type="submit">Submit</button>
     </SmartForm>

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -22,7 +22,7 @@ It will be exposed to global as `window.Vorms`
 <script setup lang="ts">
 import { useForm } from '@vorms/core'
 
-const sugarOptions = ['no', 'light', 'half', 'half', 'standard']
+const sugarOptions = ['no', 'light', 'half', 'standard']
 
 const { register, handleSubmit, handleReset } = useForm({
   initialValues: {

--- a/docs/zh-tw/advanced/smart-form-component.md
+++ b/docs/zh-tw/advanced/smart-form-component.md
@@ -12,7 +12,7 @@ import SmartSelect from './components/SmartSelect.vue'
 
 interface Values {
   drink: string,
-  sugar: 'no' | 'light' | 'half' | 'half' | 'standard'
+  sugar: 'no' | 'light' | 'half' | 'standard'
 }
 
 const initialValues = {
@@ -31,7 +31,7 @@ const onSubmit = (values: Values) => {
   <div>
     <SmartForm :initial-values="initialValues" @submit="onSubmit">
       <SmartTextField name="name" />
-      <SmartSelect name="sugar" :options="['no', 'light', 'half', 'half', 'standard']" />
+      <SmartSelect name="sugar" :options="['no', 'light', 'half', 'standard']" />
 
       <button type="submit">Submit</button>
     </SmartForm>

--- a/docs/zh-tw/guide/index.md
+++ b/docs/zh-tw/guide/index.md
@@ -21,7 +21,7 @@ npm install @vorms/core
 <script setup lang="ts">
 import { useForm } from '@vorms/core'
 
-const sugarOptions = ['no', 'light', 'half', 'half', 'standard']
+const sugarOptions = ['no', 'light', 'half', 'standard']
 
 const { register, handleSubmit, handleReset } = useForm({
   initialValues: {


### PR DESCRIPTION
<!--- ☝️ PR title should follow conventional commits (https://conventionalcommits.org). -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
- Unify 'half' enum definition to remove duplicates.
- Ignore JetBrains '.idea' folder.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guidelines](https://github.com/Mini-ghost/vorms/blob/main/CONTRIBUTING.md).
- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
